### PR TITLE
Adding author to frontmatter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This file contains a detailed description of what a specific template definition
 A template `README.md` MUST include the following metadata defined as YAML frontmatter:
 
 - `name` – The name of the pipeline template.
-- `categories` – The categories this pipeline template will be grouped under.
+- `tags` – The attributes the pipeline template will be grouped by. Such as NextJS, Rails, Ruby, AWS or Deploy.
+- `author` - The author of the pipeline template
 
 ### `pipeline.yaml`
 
@@ -29,7 +30,7 @@ A Buildkite Pipeline definition [file](https://buildkite.com/docs/pipelines/defi
 
 ## DatoCMS
 
-The templates defined in this repository are ingesting into DatoCMS.
+The templates defined in this repository are ingested into DatoCMS.
 
 ```mermaid
 


### PR DESCRIPTION
Changing the metadata described in the Readme.

Change `categories` into `tags` and adding `author`.