### PR TITLE
Update template metadata

### DIFF
--- a/.buildkite/lib/parseTemplate.ts
+++ b/.buildkite/lib/parseTemplate.ts
@@ -8,9 +8,11 @@ import { join } from "https://deno.land/std@0.205.0/path/join.ts";
 interface Frontmatter {
   title: string;
   description: string;
-  tags: string[];
-  categories: string[];
   author: string;
+  languages: string[];
+  use_cases: string[];
+  platforms: string[];
+  tools: string[];
 }
 
 export type Template = Frontmatter & {
@@ -44,6 +46,7 @@ export async function parseTemplate(path: string): Promise<Template> {
   };
 }
 
+// deno-lint-ignore no-explicit-any
 const validateFrontmatter = (meta: any): Frontmatter & { errors: string[] } => {
   const errors = [];
 
@@ -55,16 +58,24 @@ const validateFrontmatter = (meta: any): Frontmatter & { errors: string[] } => {
     errors.push("missing description");
   }
 
-  if (!meta.tags) {
-    errors.push("missing tags");
-  }
-
-  if (!meta.categories) {
-    errors.push("missing categories");
-  }
-
   if (!meta.author) {
     errors.push("missing author");
+  }
+
+  if (!meta.tools) {
+    errors.push("missing tools");
+  }
+
+  if (!meta.platforms) {
+    errors.push("missing platforms");
+  }
+
+  if (!meta.use_cases) {
+    errors.push("missing use_cases");
+  }
+
+  if (!meta.languages) {
+    errors.push("missing languages");
   }
 
   return { ...meta, errors };

--- a/.buildkite/publishContent.ts
+++ b/.buildkite/publishContent.ts
@@ -67,8 +67,10 @@ async function upsertTemplate(template: Template) {
 
   const payload = {
     ...template,
-    tags: JSON.stringify(template.tags),
-    categories: toDatoCategories(template.categories),
+    language: JSON.stringify(template.language),
+    use_case: JSON.stringify(template.use_case),
+    platform: JSON.stringify(template.platform),
+    tools: JSON.stringify(template.tools),
     content: await toDatoStructuredText(template.content),
   };
 

--- a/bash-script/README.md
+++ b/bash-script/README.md
@@ -1,9 +1,11 @@
 ---
 title: "Bash"
 description: "Execute a custom bash script"
-tags: []
 author: Buildkite
-categories: ["CI"]
+use_cases: ["CI"]
+languages: ["Bash"]
+platforms: []
+tools: []
 ---
 
 # Run a bash script

--- a/bazel-ci/README.md
+++ b/bazel-ci/README.md
@@ -1,9 +1,11 @@
 ---
 title: Bazel
 description: Starter CI pipeline for a Bazel project.
-tags: []
 author: Buildkite
-categories: ["CI"]
+use_cases: ["CI"]
+languages: ["Java"]
+platforms: []
+tools: ["Bazel"]
 ---
 
 # Building with Bazel

--- a/fastlane-ios/README.md
+++ b/fastlane-ios/README.md
@@ -1,9 +1,11 @@
 ---
 title: Fastlane for iOS
 description: Set up CI of iOS projects with Fastlane
-tags: ["Fastlane", "CI", "iOS"]
 author: Buildkite
-categories: ["CI"]
+use_cases: ["CI", "iOS"]
+languages: ["Ruby"]
+platforms: ["Fastlane"]
+tools: []
 ---
 
 # CI for iOS with Fastlane

--- a/golang-cross-compile/README.md
+++ b/golang-cross-compile/README.md
@@ -1,9 +1,11 @@
 ---
 title: "Golang"
 description: "Cross-compile a golang binary for multiple targets."
-tags: []
 author: Buildkite
-categories: ["Go", "CI"]
+use_cases: ["CI"]
+languages: ["Go"]
+platforms: []
+tools: []
 ---
 
 # Cross compiling a Golang binary

--- a/nodejs-ci/README.md
+++ b/nodejs-ci/README.md
@@ -1,9 +1,11 @@
 ---
 title: Node.js + npm + Jest + Cypress
 description: Set up Jest and Cypress testing on a Node web app
-tags: ["CI", "Node.js"]
 author: Buildkite
-categories: ["JavaScript", "CI"]
+languages: ["JavaScript"]
+use_cases: ["CI"]
+platforms: ["Docker"]
+tools: ["npm", "Jest", "Cypress"]
 ---
 
 # CI for Node.js with npm, Jest, and Cypress

--- a/php-ci/README.md
+++ b/php-ci/README.md
@@ -1,9 +1,11 @@
 ---
 title: PHP + PHPUnit + Composer
 description: Set up a CI pipeline for a PHP application with linting and testing, using PHP's built-in linter, PHPUnit, and Composer.
-tags: ["CI", "PHP", "PHPUnit", "Composer"]
 author: Buildkite
-categories: ["PHP", "CI"]
+languages: ["PHP"]
+use_cases: ["CI"]
+tools: ["composer", "phpunit"]
+platforms: []
 ---
 
 # CI/CD for PHP with Linting, Testing, and Building

--- a/pulumi-ci-cd/README.md
+++ b/pulumi-ci-cd/README.md
@@ -1,9 +1,11 @@
 ---
 title: Pulumi + AWS + Node.js + npm
 description: Preview and deploy Pulumi changes to AWS using Node.js and npm
-tags: ["IaC", "Node.js", "Pulumi", "AWS"]
 author: "Buildkite"
-categories: ["IaC", "CI"]
+use_cases: ["IaC", "CI"]
+languages: ["JavaScript"]
+platforms: ["Pulumi", "Docker", "AWS"]
+tools: []
 ---
 
 # CI/CD for Pulumi projects with AWS, Node.js, and npm

--- a/python-ci/README.md
+++ b/python-ci/README.md
@@ -1,9 +1,11 @@
 ---
 title: Python + pip + ruff + pytest
 description: Set up a CI pipeline for a Python application with linting and testing
-tags: ["CI", "Python", "pip", "pytest", "ruff", "junit"]
 author: Buildkite
-categories: ["Python", "CI"]
+languages: ["Python"]
+use_cases: ["CI"]
+platforms: ["Docker"]
+tools: ["pip", "pytest", "ruff", "junit"]
 ---
 
 # CI for Python with pip, pytest and Ruff

--- a/ruby-ci/README.md
+++ b/ruby-ci/README.md
@@ -1,9 +1,11 @@
 ---
 title: Ruby + Bundler + RuboCop + RSpec
 description: Set up a CI/CD pipeline for a Ruby application with linting and testing
-tags: ["CI", "Ruby", "RuboCop", "RSpec", "Bundler"]
 author: Buildkite
-categories: ["Ruby", "CI"]
+languages: ["Ruby"]
+use_cases: ["CI"]
+platforms: ["Docker"]
+tools: ["Bundler", "RuboCop", "RSpec"]
 ---
 
 # CI/CD for Ruby with Bundler, Rubocop, and RSpec

--- a/rust-ci/README.md
+++ b/rust-ci/README.md
@@ -1,9 +1,11 @@
 ---
 title: Rust + Clippy + Cargo
 description: Set up a CI/CD pipeline for a Rust application with linting, testing, and building using Clippy and Cargo.
-tags: ["CI", "Rust", "Clippy", "Cargo"]
 author: Buildkite
-categories: ["Rust", "CI"]
+languages: ["Rust"]
+use_cases: ["CI"]
+platforms: ["Docker"]
+tools: ["clippy", "cargo"]
 ---
 
 # CI/CD for Rust with Linting, Testing, and Building


### PR DESCRIPTION
This PR re-structures template metadata to make it easier to parse and search on. Specifically, it replaces `categories` and `tags` with: `languages`, `platforms`, `use_cases`, and `tools`. 