### PR TITLE
Fix DatoCMS attribute names

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,7 +3,7 @@ steps:
     key: "validate"
     steps:
       - label: ":buildkite: Validate pipelines"
-        command: deno run -A --quiet .buildkite/validatePipeline.ts
+        command: deno run --check -A --quiet .buildkite/validatePipeline.ts
         plugins: &deno
           - docker#v5.9.0:
               image: "denoland/deno:1.38.0"
@@ -17,6 +17,6 @@ steps:
   - label: ":datocms: Publish templates"
     depends_on: "validate"
     key: "publish"
-    command: deno run -A --quiet .buildkite/publishContent.ts
+    command: deno run --check -A --quiet .buildkite/publishContent.ts
     if: build.branch == "main"
     plugins: *deno

--- a/.buildkite/publishContent.ts
+++ b/.buildkite/publishContent.ts
@@ -42,9 +42,9 @@ async function upsertTemplate(template: Template) {
 
   const payload = {
     ...template,
-    language: JSON.stringify(template.languages),
-    use_case: JSON.stringify(template.use_cases),
-    platform: JSON.stringify(template.platforms),
+    languages: JSON.stringify(template.languages),
+    use_cases: JSON.stringify(template.use_cases),
+    platforms: JSON.stringify(template.platforms),
     tools: JSON.stringify(template.tools),
     content: await toDatoStructuredText(template.content),
   };


### PR DESCRIPTION
This is a follow up from https://github.com/buildkite/templates/pull/56 where I used some invalid attributes.

This change adds some type checking to catch some errors earlier, and uses the correct DatoCMS attributes.