### PR TITLE
GROW-506 Add template for README to the repo

### DIFF
--- a/BLANK_README.md
+++ b/BLANK_README.md
@@ -1,0 +1,100 @@
+<!--
+*** This is a example README that you can edit to suit your needs.
+*** After you've edited this file, delete this comment block 
+*** and ensure that there are no leading spaces before the front matter.
+*** Then, save this file as README.md in the directory for your template.
+*** If you have any trouble, submit a PR, and we'll get back to you.
+*** Thank you!
+***
+***
+*** Front Matter Key
+***
+*** title: <List of key tech separated by ‘+’>
+*** description: <Short description of the use case>
+*** author: <Organization or person in double quotes>
+*** use_cases: <Array of use cases in format ["IaC", "CI"]>
+*** languages: <Array of programming languages in format ["JavaScript", "Go"]>
+*** platforms: <Array of platforms in format ["Pulumi", "Docker", "AWS"]>
+*** tools: <Array of tools in format ["clippy", "cargo"]>
+***
+***
+*** Content Guide
+***
+*** H1: CI/CD for <technology> with <key features>
+*** Intro paragraph: This template gives you a continuous integration and 
+*** continuous deployment (CI/CD) pipeline that <high-level description of pipeline goal>.
+***
+*** At a glance:
+*** - For <X>
+*** - Uses <X>
+*** - Requires <X>
+*** - <Additional relevant behavior>
+*** - Deploys to <X>
+***
+*** H2: How it works
+*** This template:
+*** 1. <Talk through steps in detail>
+*** 2. <...More steps...>
+*** <Additional details about how the pipeline runs and the runtime environment>
+***
+*** H2: Next steps
+*** After you select **Use template**, you’ll:
+*** 1. Connect the Git repository with your <X>.
+*** 2. <Any modifications to the template like commands, environment variables, secrets>
+*** 3. Configure the compute—run locally, on-premises, or in the cloud.
+*** 4. Run the pipeline.
+***
+*** Footer:
+*** <You can then play around...>
+*** <If you need help,...>
+-->
+
+---
+title: Pulumi + AWS + Node.js + npm
+description: Preview and deploy Pulumi changes to AWS using Node.js and npm
+author: "Buildkite"
+use_cases: ["IaC", "CI"]
+languages: ["JavaScript"]
+platforms: ["Pulumi", "Docker", "AWS"]
+tools: []
+---
+
+# CI/CD for Pulumi projects with AWS, Node.js, and npm
+
+This template gives you a continuous integration and continuous deployment (CI/CD) pipeline that previews a Pulumi change before deploying it to AWS.
+
+At a glance:
+
+- For [Pulumi projects](https://www.pulumi.com/)
+- Uses [Node.js](https://www.pulumi.com/) and [npm](https://www.npmjs.com/)
+- Requires [Docker](https://www.npmjs.com/)
+- Prompts for confirmation before deploying
+- Deploys to [AWS](https://aws.amazon.com/)
+
+## How it works
+
+This template:
+
+1. Assumes a role in AWS using Buildkite’s OIDC.
+2. Installs Node dependencies using npm.
+3. Prints a preview of the Pulumi change in an annotation on the build.
+4. Asks for manual confirmation to deploy the change.
+5. Deploys the Pulumi change to AWS with `pulumi up`.
+
+The runtime environment uses a Docker image with the Pulumi CLI and Node.js.
+
+## Next steps
+
+After you select **Use template**, you’ll:
+
+1. Connect the Git repository with your Pulumi code.
+2. Set Buildkite as an OIDC provider in AWS.
+3. Set the `AWS_ROLE_ARN` environment variable to a role with permission to deploy Pulumi changes to your AWS account.
+4. Set the `PULUMI_STACK` environment variable to the [Pulumi Stack](https://buildkite.com/support) being deployed.
+5. Store `PULUMI_ACCESS_TOKEN` in your pipeline secrets.
+6. Configure the compute—run locally, on-premises, or in the cloud.
+7. Run the pipeline.
+
+You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
+
+If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
-# Contributing
+# How to contribute a pipeline template
 
-## Creating a new template
-
-A pipeline template should be defined using the following structure:
+You can add a new pipeline template to this repo by using the following structure:
 
 ```
 .
@@ -13,22 +11,17 @@ A pipeline template should be defined using the following structure:
         └── ...
 ```
 
-### `README.md`
-
-This file contains a detailed description of what a specific template definition is and how it works.
-
-A template `README.md` MUST include the following metadata defined as YAML frontmatter:
-
-- `name` – The name of the pipeline template.
-- `description` – The meta description for the template.
-- `tags` – The attributes the pipeline template will be grouped by. Such as NextJS, Rails, Ruby, AWS or Deploy.
-- `author` - The author of the pipeline template
-
-### `pipeline.yaml`
+## `pipeline.yaml`
 
 A Buildkite Pipeline definition [file](https://buildkite.com/docs/pipelines/defining-steps).
 
-### `example-project` (optional)
+## `README.md`
+
+Your `README.md` should contain a high-level description of your template definition and how it works.
+
+Use the [`BLANK_README.md`](https://github.com/buildkite/templates/blob/main/BLANK_README.md) file in the root directory of this repo to get started. It contains example text along with a key to required front matter, plus a content guide.
+
+## `example-project` (optional)
 
 Having an example project with relevant boilerplate makes it possible to test pipeline yaml in isolation.
 
@@ -39,9 +32,9 @@ cd my-template-ci/example;
 bk local run ../pipeline.yaml
 ```
 
-## DatoCMS
+# Publication on Buildkite.com
 
-The templates defined in this repository are ingested into DatoCMS.
+The templates defined in this repository are ingested into DatoCMS. There are two human review stages: once via PR in this repo, and another via approval in DatoCMS.
 
 ```mermaid
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ bk local run ../pipeline.yaml
 
 # Publication on Buildkite.com
 
-The templates defined in this repository are ingested into DatoCMS. There are two human review stages: once via PR in this repo, and another via approval in DatoCMS.
+The templates defined in this repository are ingested into DatoCMS on merge.
 
 ```mermaid
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ A collection of [Buildkite](https://buildkite.com) pipeline templates.
 
 ## Contributing
 
-See [CONTRIBUTING](./CONTRIBUTING.md) for more details on contributing fixes, issues, and PRs.
+See [CONTRIBUTING](./CONTRIBUTING.md) for more details on how to constribute additional pipeline templates.


### PR DESCRIPTION
This PR adds a template README called BLANK_README.md that contributors can use to add new pipeline templates to this repo. It also updates information on the CONTRIBUTING.md instructions to reflect the new file, and makes a slight change to the repo's own README.md to reflect the contents of CONTRIBUTING.md.

So, at a high level you should see:
- A new file called BLANK_README.md at the root level that you'll need to review as code (not preview) because there are instructions in comments
- New instructions in CONTRIBUTING.md that take advantage of the new helper README.

WISH LIST: I didn't know which of the front matter is required, and which is optional. I would like to add this information to the "front matter key" in BLANK_README.md, if known.