### PR TITLE
Trigger site deployment after publishing content

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -20,3 +20,10 @@ steps:
     command: deno run --check -A --quiet .buildkite/publishContent.ts
     if: build.branch == "main"
     plugins: *deno
+
+  - trigger: "site"
+    depends_on: "publish"
+    if: build.branch == "main"
+    label: ":buildkite: Trigger site build"
+    build:
+      message: "Triggered by buildkite/templates"


### PR DESCRIPTION
This PR adds a new CI step to re-deploy the buildkite marketing site in order to SSG template pages.