### PR TITLE
Validate emojis against JSON dataset

### DIFF
--- a/.buildkite/lib/isValidEmoji.ts
+++ b/.buildkite/lib/isValidEmoji.ts
@@ -1,0 +1,28 @@
+interface Emoji {
+  name: string;
+  aliases: string[];
+}
+
+const buildkiteEmojis = await fetch(
+  "https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64.json"
+)
+  .then((res) => res.json())
+  .then((json) =>
+    json.map((emoji: Emoji) => [emoji.name, ...emoji.aliases]).flat()
+  );
+
+const appleEmojis = await fetch(
+  "https://raw.githubusercontent.com/buildkite/emojis/main/img-apple-64.json"
+)
+  .then((res) => res.json())
+  .then((json) =>
+    json.map((emoji: Emoji) => [emoji.name, ...emoji.aliases]).flat()
+  );
+
+const emojis = [...buildkiteEmojis, ...appleEmojis]
+  .filter((e) => e && e.length > 1)
+  .sort();
+
+export default function isValidEmoji(emoji: string) {
+  return emojis.includes(emoji);
+}

--- a/.buildkite/lib/parseTemplate.ts
+++ b/.buildkite/lib/parseTemplate.ts
@@ -4,6 +4,7 @@ import { matter } from "npm:vfile-matter";
 import { read } from "npm:to-vfile";
 import fs from "node:fs";
 import { join } from "https://deno.land/std@0.205.0/path/join.ts";
+import isValidEmoji from "./isValidEmoji.ts";
 
 interface Frontmatter {
   title: string;
@@ -47,12 +48,6 @@ export async function parseTemplate(path: string): Promise<Template> {
   };
 }
 
-const emojis = await fetch(
-  "https://raw.githubusercontent.com/buildkite/emojis/main/all_emoji_names.txt"
-)
-  .then((res) => res.text())
-  .then((text) => text.split("\n"));
-
 // deno-lint-ignore no-explicit-any
 const validateFrontmatter = (meta: any): Frontmatter & { errors: string[] } => {
   const errors = [];
@@ -89,7 +84,7 @@ const validateFrontmatter = (meta: any): Frontmatter & { errors: string[] } => {
     errors.push("template must have at least one `primary_emoji`");
   } else {
     for (const emoji of meta.primary_emojis) {
-      if (!emojis.includes(emoji.replace(/:/g, ""))) {
+      if (!isValidEmoji(emoji.replace(/:/g, ""))) {
         errors.push(
           `invalid emoji: ${emoji}, see https://github.com/buildkite/emojis for a list of valid emojis`
         );


### PR DESCRIPTION
Turns out [`all_emoji_names.txt`](https://raw.githubusercontent.com/buildkite/emojis/main/all_emoji_names.txt) isn't the source of truth for Buildkite emojis.

This change validates template emojis against the following files:

- https://github.com/buildkite/emojis/blob/main/img-buildkite-64.json
- https://github.com/buildkite/emojis/blob/main/img-apple-64.json

