### PR TITLE
Inline docker image tags

### DIFF
--- a/golang-cross-compile/pipeline.yaml
+++ b/golang-cross-compile/pipeline.yaml
@@ -1,5 +1,6 @@
 steps:
-  - plugins:
+  - label: ":golang: Cross compile"
+    plugins:
       - golang-cross-compile#v1.4.0:
           build: main.go
           targets:

--- a/nodejs-ci/pipeline.yaml
+++ b/nodejs-ci/pipeline.yaml
@@ -1,6 +1,3 @@
-env:
-  NODE_VERSION: "latest"
-
 steps:
   - label: ":npm: Install dependencies"
     key: "deps"
@@ -12,7 +9,7 @@ steps:
           restore: file
           save: file
       - docker#v5.9.0:
-          image: "node:${NODE_VERSION}"
+          image: "node:latest"
 
   - label: ":eslint: Run ESLint"
     command: "npx eslint"
@@ -23,7 +20,7 @@ steps:
           path: node_modules
           restore: file
       - docker#v5.9.0:
-          image: "node:${NODE_VERSION}"
+          image: "node:latest"
 
   - label: ":jest: Run unit tests"
     depends_on: "deps"

--- a/python-ci/pipeline.yaml
+++ b/python-ci/pipeline.yaml
@@ -1,13 +1,10 @@
-env:
-  PYTHON_VERSION: "latest"
-
 steps:
   - label: ":pip: Install dependencies"
     key: "pip"
     command: pip install -r requirements.txt
     plugins:
       - docker#v5.9.0:
-          image: "python:${PYTHON_VERSION}"
+          image: "python:latest"
 
   - label: Lint with Ruff
     depends_on: ["pip"]
@@ -16,7 +13,7 @@ steps:
       ruff check .
     plugins:
       - docker#v5.9.0:
-          image: "python:${PYTHON_VERSION}"
+          image: "python:latest"
 
   - label: ":pytest: Run pytest"
     key: "pytest"
@@ -28,7 +25,7 @@ steps:
       - junit/test-results.xml
     plugins:
       - docker#v5.9.0:
-          image: "python:${PYTHON_VERSION}"
+          image: "python:latest"
 
   - label: ":junit: Annotate"
     depends_on: ["pytest"]

--- a/ruby-ci/pipeline.yaml
+++ b/ruby-ci/pipeline.yaml
@@ -1,5 +1,4 @@
 env:
-  RUBY_VERSION: latest
   BUNDLE_PATH: vendor/bundle
 
 steps:
@@ -8,7 +7,7 @@ steps:
     key: "gems"
     plugins:
       - docker#v5.9.0:
-          image: "ruby:$RUBY_VERSION"
+          image: "ruby:latest"
           environment:
             - BUNDLE_PATH
       - cache#v0.6.0:
@@ -22,7 +21,7 @@ steps:
     depends_on: "gems"
     plugins:
       - docker#v5.9.0:
-          image: "ruby:$RUBY_VERSION"
+          image: "ruby:latest"
           environment:
             - BUNDLE_PATH
       - cache#v0.6.0:
@@ -35,7 +34,7 @@ steps:
     depends_on: "gems"
     plugins:
       - docker#v5.9.0:
-          image: "ruby:$RUBY_VERSION"
+          image: "ruby:latest"
           environment:
             - BUNDLE_PATH
       - cache#v0.6.0:

--- a/rust-ci/pipeline.yaml
+++ b/rust-ci/pipeline.yaml
@@ -1,6 +1,3 @@
-env:
-  RUST_VERSION: "1.74.1"
-
 steps:
   - label: ":rust: Lint"
     key: lint
@@ -9,20 +6,20 @@ steps:
       - "cargo clippy"
     plugins:
       - docker#v5.9.0:
-          image: "rust:${RUST_VERSION}"
+          image: "rust:1.74.1"
 
   - label: ":rust: Test"
     key: test
     command: "cargo test"
     plugins:
       - docker#v5.9.0:
-          image: "rust:${RUST_VERSION}"
+          image: "rust:1.74.1"
 
   - label: ":rust: Build"
     command: "cargo build --release"
     depends_on: ["lint", "test"]
     plugins:
       - docker#v5.9.0:
-          image: "rust:${RUST_VERSION}"
+          image: "rust:1.74.1"
     artifact_paths:
       - "target/release/*"


### PR DESCRIPTION
Avoid using environment variables for docker images to make individual steps more readable. This is especially the case when rendering steps in the playground.

Closes GROW-684