### PR TITLE
Replace cache plugin with artifacts plugin

### DIFF
--- a/nodejs-ci/example-project/.gitignore
+++ b/nodejs-ci/example-project/.gitignore
@@ -1,0 +1,1 @@
+node_modules.tgz

--- a/nodejs-ci/pipeline.yaml
+++ b/nodejs-ci/pipeline.yaml
@@ -3,11 +3,9 @@ steps:
     key: "deps"
     command: npm install
     plugins:
-      - cache#v0.6.0:
-          manifest: package-lock.json
-          path: node_modules
-          restore: file
-          save: file
+      - artifacts#v1.9.3:
+          upload: "node_modules"
+          compressed: node_modules.tgz
       - docker#v5.9.0:
           image: "node:latest"
 
@@ -15,10 +13,9 @@ steps:
     command: "npx eslint"
     depends_on: "deps"
     plugins:
-      - cache#v0.6.0:
-          manifest: package-lock.json
-          path: node_modules
-          restore: file
+      - artifacts#v1.9.3:
+          download: "node_modules"
+          compressed: node_modules.tgz
       - docker#v5.9.0:
           image: "node:latest"
 
@@ -26,10 +23,9 @@ steps:
     depends_on: "deps"
     command: "npx jest"
     plugins:
-      - cache#v0.6.0:
-          manifest: package-lock.json
-          path: node_modules
-          restore: file
+      - artifacts#v1.9.3:
+          download: "node_modules"
+          compressed: node_modules.tgz
       - docker#v5.9.0:
           image: "node:latest"
 

--- a/php-ci/example-project/.gitignore
+++ b/php-ci/example-project/.gitignore
@@ -1,1 +1,2 @@
 vendor
+vendor.tgz

--- a/php-ci/pipeline.yaml
+++ b/php-ci/pipeline.yaml
@@ -5,11 +5,9 @@ steps:
     plugins:
       - docker#v5.9.0:
           image: "composer:latest"
-      - cache#v0.6.0:
-          manifest: composer.lock
-          path: vendor
-          restore: file
-          save: file
+      - artifacts#v1.9.3:
+          upload: "vendor"
+          compressed: vendor.tgz
 
   - label: ":php: Lint"
     depends_on: "composer"
@@ -17,10 +15,9 @@ steps:
     plugins:
       - docker#v5.9.0:
           image: "php:latest"
-      - cache#v0.6.0:
-          manifest: composer.lock
-          path: vendor
-          restore: file
+      - artifacts#v1.9.3:
+          download: "vendor"
+          compressed: vendor.tgz
 
   - label: ":phpunit: Run phpunit"
     depends_on: "composer"
@@ -28,7 +25,6 @@ steps:
     plugins:
       - docker#v5.9.0:
           image: "php:latest"
-      - cache#v0.6.0:
-          manifest: composer.lock
-          path: vendor
-          restore: file
+      - artifacts#v1.9.3:
+          download: "vendor"
+          compressed: vendor.tgz

--- a/ruby-ci/example-project/.gitignore
+++ b/ruby-ci/example-project/.gitignore
@@ -1,1 +1,2 @@
 vendor/bundle
+vendor/bundle.tgz

--- a/ruby-ci/pipeline.yaml
+++ b/ruby-ci/pipeline.yaml
@@ -10,11 +10,9 @@ steps:
           image: "ruby:latest"
           environment:
             - BUNDLE_PATH
-      - cache#v0.6.0:
-          manifest: Gemfile.lock
-          path: vendor/bundle
-          restore: file
-          save: file
+      - artifacts#v1.9.3:
+          upload: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz
 
   - label: ":rubocop: Run rubocop"
     command: "bundle exec rubocop"
@@ -24,10 +22,9 @@ steps:
           image: "ruby:latest"
           environment:
             - BUNDLE_PATH
-      - cache#v0.6.0:
-          manifest: Gemfile.lock
-          path: vendor/bundle
-          restore: file
+      - artifacts#v1.9.3:
+          download: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz
 
   - label: ":rspec: Run rspec"
     command: "bundle exec rspec"
@@ -37,7 +34,6 @@ steps:
           image: "ruby:latest"
           environment:
             - BUNDLE_PATH
-      - cache#v0.6.0:
-          manifest: Gemfile.lock
-          path: vendor/bundle
-          restore: file
+      - artifacts#v1.9.3:
+          download: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz


### PR DESCRIPTION
The default [`fs` backend](https://github.com/buildkite-plugins/cache-buildkite-plugin?tab=readme-ov-file#backend-string) for the cache-plugin requires a folder to exist prior to using the plugin.

This makes the first experience running some of these templates not-so-great. https://github.com/buildkite-plugins/cache-buildkite-plugin/issues/54

Following the approach of a few other templates, this switches a handful of template over to using the [buildkite artifacts plugin](https://github.com/buildkite-plugins/artifacts-buildkite-plugin), using build artifacts as the method for caching project dependencies. 