### PR TITLE
Deploy docker image to Fly.io 

### DIFF
--- a/flyio-docker/README.md
+++ b/flyio-docker/README.md
@@ -1,0 +1,36 @@
+---
+title: CI/CD for Fly.io
+description: Build and deploy a Docker image to Fly.io.
+author: Buildkite
+languages: []
+use_cases: ["CD", "CI"]
+platforms: ["Fly.io", "Docker"]
+tools: ["Docker"]
+primary_emojis: [":fly-io:"]
+---
+
+# CI/CD for Fly.io
+
+This template gives you a continuous deployment (CD) pipeline that builds and deploys a docker image to Fly.io.
+
+At a glance:
+
+- For [Fly.io](https://fly.io/) applications
+- Uses [Docker](https://github.com/buildkite-plugins/docker-buildkite-plugin)
+- Uses [flyctl](https://github.com/dannymidnight/setup-flyctl-buildkite-plugin)
+
+## How it works
+
+This template:
+
+1. Builds and pushes a Docker image to the Fly.io registry.
+2. Deploys image to Fly.io.
+
+## Next steps
+
+After you select **Use template**, you’ll:
+
+1. Connect the Git repository with your Fly.io application.
+2. Configure Buildkite with the following secrets: `FLY_ACCESS_TOKEN`, `FLY_APP_NAME`.
+3. Configure the compute—run locally, on-premises, or in the cloud.
+4. Run the pipeline.

--- a/flyio-docker/example-project/Dockerfile
+++ b/flyio-docker/example-project/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/flyio-docker/example-project/fly.toml
+++ b/flyio-docker/example-project/fly.toml
@@ -1,0 +1,22 @@
+# fly.toml app configuration file generated for example-project-rough-sunset-2869 on 2024-03-14T22:39:39+11:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'example-project'
+primary_region = 'syd'
+
+[build]
+
+[http_service]
+internal_port = 80
+force_https = true
+auto_stop_machines = true
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[[vm]]
+memory = '1gb'
+cpu_kind = 'shared'
+cpus = 1

--- a/flyio-docker/example-project/index.html
+++ b/flyio-docker/example-project/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/flyio-docker/pipeline.yaml
+++ b/flyio-docker/pipeline.yaml
@@ -1,5 +1,5 @@
 env:
-  APP_NAME: "example-project"
+  FLY_APP_NAME: "example-project"
   PLATFORM: "linux/amd64"
 
 steps:
@@ -9,11 +9,11 @@ steps:
       - dannymidnight/setup-flyctl
     commands: |
       fly auth docker
-      docker build -t registry.fly.io/${APP_NAME}:${BUILDKITE_COMMIT} --platform ${PLATFORM} .
-      docker push registry.fly.io/${APP_NAME}:${BUILDKITE_COMMIT}
+      docker build -t registry.fly.io/${FLY_APP_NAME}:${BUILDKITE_COMMIT} --platform ${PLATFORM} .
+      docker push registry.fly.io/${FLY_APP_NAME}:${BUILDKITE_COMMIT}
 
   - label: ":fly-io: fly deploy"
     depends_on: "build"
     plugins:
       - dannymidnight/setup-flyctl
-    command: "flyctl deploy -i registry.fly.io/${APP_NAME}:${BUILDKITE_COMMIT}"
+    command: "flyctl deploy -i registry.fly.io/${FLY_APP_NAME}:${BUILDKITE_COMMIT}"

--- a/flyio-docker/pipeline.yaml
+++ b/flyio-docker/pipeline.yaml
@@ -1,0 +1,5 @@
+steps:
+  - label: ":fly-io: fly deploy"
+    plugins:
+      - dannymidnight/setup-flyctl
+    command: "flyctl deploy"

--- a/flyio-docker/pipeline.yaml
+++ b/flyio-docker/pipeline.yaml
@@ -1,5 +1,19 @@
+env:
+  APP_NAME: "example-project"
+  PLATFORM: "linux/amd64"
+
 steps:
-  - label: ":fly-io: fly deploy"
+  - label: ":docker: docker build and push"
+    key: "build"
     plugins:
       - dannymidnight/setup-flyctl
-    command: "flyctl deploy"
+    commands: |
+      fly auth docker
+      docker build -t registry.fly.io/${APP_NAME}:${BUILDKITE_COMMIT} --platform ${PLATFORM} .
+      docker push registry.fly.io/${APP_NAME}:${BUILDKITE_COMMIT}
+
+  - label: ":fly-io: fly deploy"
+    depends_on: "build"
+    plugins:
+      - dannymidnight/setup-flyctl
+    command: "flyctl deploy -i registry.fly.io/${APP_NAME}:${BUILDKITE_COMMIT}"

--- a/vercel-deploy/README.md
+++ b/vercel-deploy/README.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy to Vercel
+title: CI/CD for Vercel
 description: Build and deploy a web application to Vercel production environment.
 author: Buildkite
 languages: ["JavaScript"]
@@ -9,7 +9,7 @@ tools: ["Next.js"]
 primary_emojis: [":vercel:"]
 ---
 
-# Deploy to Vercel
+# CI/CD for Vercel
 
 This templates gives you a continuous deployment (CD) pipeline that builds and deploys a web application to Vercel.
 


### PR DESCRIPTION
Taking inspiration from https://community.fly.io/t/continuous-deployment-with-buildkite/78/4, this adds a new template for deploying a docker image to Fly.io.

Closes https://github.com/buildkite/templates/issues/81

Along the way I decided to add a new Buildkite plugin to make the whole thing easier to follow.

https://github.com/dannymidnight/setup-flyctl-buildkite-plugin.

<img width="1624" alt="Screenshot 2024-03-15 at 10 49 56 am" src="https://github.com/buildkite/templates/assets/656826/660126e0-9b12-422f-bfb9-18ff228953ec">

TODO:
- [x] Add README
