### PR TITLE
Move template footer into page layout

### DIFF
--- a/EXAMPLE_README.md
+++ b/EXAMPLE_README.md
@@ -47,10 +47,6 @@
 *** 2. <Any modifications to the template like commands, environment variables, secrets>
 *** 3. Configure the compute—run locally, on-premises, or in the cloud.
 *** 4. Run the pipeline.
-***
-*** Footer:
-*** <You can then play around...>
-*** <If you need help,...>
 -->
 
 ---
@@ -99,7 +95,3 @@ After you select **Use template**, you’ll:
 5. Store `PULUMI_ACCESS_TOKEN` in your pipeline secrets.
 6. Configure the compute—run locally, on-premises, or in the cloud.
 7. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/bash-script/README.md
+++ b/bash-script/README.md
@@ -32,7 +32,3 @@ After you select **Use template**, you’ll:
 1. Connect the Git repository with your code.
 2. Configure the compute—run locally, on-premises, or in the cloud.
 3. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/bazel-ci/README.md
+++ b/bazel-ci/README.md
@@ -34,8 +34,4 @@ After you select **Use template**, you’ll:
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
 
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
 For more information about advanced Bazel usage, see [How Bazel built its CI system on top of Buildkite](https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite).
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -36,7 +36,3 @@ After you select **Use template**, you’ll:
 1. Connect the Git repository for your .NET application.
 2. Configure the compute—run locally, on-premises, or in the cloud.
 3. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/fastlane-ios/README.md
+++ b/fastlane-ios/README.md
@@ -43,7 +43,3 @@ After you select **Use template**, you’ll:
    - `lint`: Runs Swift code validation using [Swiftlint](http://docs.fastlane.tools/actions/swiftlint).
    - `build`: Builds the app using [gym](http://docs.fastlane.tools/actions/gym).
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/golang-ci/README.md
+++ b/golang-ci/README.md
@@ -33,6 +33,6 @@ The runtime environment uses the official [Golang Docker image](https://hub.dock
 
 After you select **Use template**, you’ll:
 
-1. Connect the Git repository with your Golang module.
+1. Connect the Git repository with your Go module.
 2. Configure the compute—run locally, on-premises, or in the cloud.
 3. Run the pipeline.

--- a/golang-ci/README.md
+++ b/golang-ci/README.md
@@ -36,7 +36,3 @@ After you select **Use template**, you’ll:
 1. Connect the Git repository with your Golang module.
 2. Configure the compute—run locally, on-premises, or in the cloud.
 3. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/golang-cross-compile/README.md
+++ b/golang-cross-compile/README.md
@@ -33,7 +33,3 @@ After you select **Use template**, you’ll:
 1. Connect the Git repository with your Go code.
 2. Configure the compute—run locally, on-premises, or in the cloud.
 3. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/java-gradle/README.md
+++ b/java-gradle/README.md
@@ -36,7 +36,3 @@ After you select **Use template**, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/kotlin-gradle/README.md
+++ b/kotlin-gradle/README.md
@@ -36,7 +36,3 @@ After you select **Use template**, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/nodejs-ci/README.md
+++ b/nodejs-ci/README.md
@@ -41,7 +41,3 @@ After you select **Use template**, you’ll:
 2. Check the commands match your scripts in `package.json`.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/php-ci/README.md
+++ b/php-ci/README.md
@@ -36,7 +36,3 @@ After you select Use template, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/pulumi-aws/README.md
+++ b/pulumi-aws/README.md
@@ -44,7 +44,3 @@ After you select **Use template**, you’ll:
 5. Store `PULUMI_ACCESS_TOKEN` in your pipeline secrets.
 6. Configure the compute—run locally, on-premises, or in the cloud.
 7. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/python-ci/README.md
+++ b/python-ci/README.md
@@ -40,5 +40,3 @@ After you select **Use template**, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.

--- a/ruby-ci/README.md
+++ b/ruby-ci/README.md
@@ -39,7 +39,3 @@ After you select **Use template**, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/rust-ci/README.md
+++ b/rust-ci/README.md
@@ -30,7 +30,7 @@ This template:
 
 ## Next steps
 
-After you select Use template, you’ll:
+After you select **Use template**, you’ll:
 
 1. Connect the Git repository with your Rust application.
 2. Modify the commands if necessary.

--- a/rust-ci/README.md
+++ b/rust-ci/README.md
@@ -36,7 +36,3 @@ After you select Use template, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/snyk-nodejs/README.md
+++ b/snyk-nodejs/README.md
@@ -37,5 +37,3 @@ After you select Use template, you’ll:
 3. [Retrieve](https://docs.snyk.io/getting-started/how-to-obtain-and-authenticate-with-your-snyk-api-token) and store `SNYK_TOKEN` in your pipeline secrets.
 4. Configure the compute—run locally, on-premises, or in the cloud.
 5. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.

--- a/snyk-nodejs/README.md
+++ b/snyk-nodejs/README.md
@@ -30,7 +30,7 @@ The runtime environment uses the official [Synk Docker image](httpshttps://githu
 
 ## Next steps
 
-After you select Use template, you’ll:
+After you select **Use template**, you’ll:
 
 1. Connect your git repository.
 2. Modify the template commands, environment variables, secrets as needed for your project.

--- a/swift/README.md
+++ b/swift/README.md
@@ -39,5 +39,3 @@ After you select Use template, you’ll:
 2. Modify the commands if necessary.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.

--- a/terraform-aws/README.md
+++ b/terraform-aws/README.md
@@ -38,7 +38,3 @@ After you select **Use template**, you’ll:
 2. Replace the placeholder AWS role ARN in the pipeline definition.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/terraform-docker/README.md
+++ b/terraform-docker/README.md
@@ -35,7 +35,3 @@ After you select **Use template**, you’ll:
 1. Connect the Git repository with your Terraform configuration.
 2. Configure the compute—run locally, on-premises, or in the cloud.
 3. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).

--- a/vercel-deploy/README.md
+++ b/vercel-deploy/README.md
@@ -36,7 +36,3 @@ After you select **Use template**, you’ll:
 2. Configure Buildkite with the following secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
 3. Configure the compute—run locally, on-premises, or in the cloud.
 4. Run the pipeline.
-
-You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
-
-If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).


### PR DESCRIPTION
This change pulls the replicated template footer from individual README's in preparation for relocating it into the page layout. 

> You can then play around with the pipeline settings. For example, run the pipeline locally while you iterate on the definition or set a schedule to trigger a nightly build.
>
> If you need help, please [check our documentation](https://buildkite.com/docs/pipelines/configuration-overview), [raise an issue](https://github.com/buildkite/templates/issues), or [reach out to support](https://buildkite.com/support).