### PR TITLE
Use specific docker image tag over `latest`

### DIFF
--- a/golang-ci/pipeline.yaml
+++ b/golang-ci/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
           upload: "vendor"
           compressed: vendor.tgz
       - docker#v5.9.0:
-          image: "golang:latest"
+          image: "golang:1.22"
 
   - label: ":golang: Build"
     command: "go build -mod=vendor main.go"
@@ -17,7 +17,7 @@ steps:
           download: "vendor"
           compressed: vendor.tgz
       - docker#v5.9.0:
-          image: "golang:latest"
+          image: "golang:1.22"
 
   - label: ":golang: Test"
     command: "go test -mod=vendor ./..."
@@ -27,7 +27,7 @@ steps:
           download: "vendor"
           compressed: vendor.tgz
       - docker#v5.9.0:
-          image: "golang:latest"
+          image: "golang:1.22"
 
   - label: ":golang: Generate"
     depends_on: ["deps"]
@@ -39,4 +39,4 @@ steps:
           download: "vendor"
           compressed: vendor.tgz
       - docker#v5.9.0:
-          image: "golang:latest"
+          image: "golang:1.22"

--- a/nodejs-ci/pipeline.yaml
+++ b/nodejs-ci/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
           upload: "node_modules"
           compressed: node_modules.tgz
       - docker#v5.9.0:
-          image: "node:latest"
+          image: "node:20.11"
 
   - label: ":eslint: Run ESLint"
     command: "npx eslint"
@@ -17,7 +17,7 @@ steps:
           download: "node_modules"
           compressed: node_modules.tgz
       - docker#v5.9.0:
-          image: "node:latest"
+          image: "node:20.11"
 
   - label: ":jest: Run unit tests"
     depends_on: "deps"
@@ -27,7 +27,7 @@ steps:
           download: "node_modules"
           compressed: node_modules.tgz
       - docker#v5.9.0:
-          image: "node:latest"
+          image: "node:20.11"
 
   - label: ":cypress: Run cypress tests"
     depends_on: "deps"

--- a/php-ci/pipeline.yaml
+++ b/php-ci/pipeline.yaml
@@ -14,7 +14,7 @@ steps:
     command: 'find -name "*.php" -not -path "./vendor/*" | xargs php -l'
     plugins:
       - docker#v5.9.0:
-          image: "php:latest"
+          image: "php:8.3"
       - artifacts#v1.9.3:
           download: "vendor"
           compressed: vendor.tgz
@@ -24,7 +24,7 @@ steps:
     command: "vendor/bin/phpunit --configuration phpunit.xml"
     plugins:
       - docker#v5.9.0:
-          image: "php:latest"
+          image: "php:8.3"
       - artifacts#v1.9.3:
           download: "vendor"
           compressed: vendor.tgz

--- a/python-ci/pipeline.yaml
+++ b/python-ci/pipeline.yaml
@@ -4,7 +4,7 @@ steps:
     command: pip install -r requirements.txt
     plugins:
       - docker#v5.9.0:
-          image: "python:latest"
+          image: "python:3.13"
 
   - label: Lint with Ruff
     depends_on: ["pip"]
@@ -13,7 +13,7 @@ steps:
       ruff check .
     plugins:
       - docker#v5.9.0:
-          image: "python:latest"
+          image: "python:3.13"
 
   - label: ":pytest: Run pytest"
     key: "pytest"
@@ -25,7 +25,7 @@ steps:
       - junit/test-results.xml
     plugins:
       - docker#v5.9.0:
-          image: "python:latest"
+          image: "python:3.13"
 
   - label: ":junit: Annotate"
     depends_on: ["pytest"]

--- a/ruby-ci/pipeline.yaml
+++ b/ruby-ci/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
     key: "gems"
     plugins:
       - docker#v5.9.0:
-          image: "ruby:latest"
+          image: "ruby:3.3"
           environment:
             - BUNDLE_PATH
       - artifacts#v1.9.3:
@@ -19,7 +19,7 @@ steps:
     depends_on: "gems"
     plugins:
       - docker#v5.9.0:
-          image: "ruby:latest"
+          image: "ruby:3.3"
           environment:
             - BUNDLE_PATH
       - artifacts#v1.9.3:
@@ -31,7 +31,7 @@ steps:
     depends_on: "gems"
     plugins:
       - docker#v5.9.0:
-          image: "ruby:latest"
+          image: "ruby:3.3"
           environment:
             - BUNDLE_PATH
       - artifacts#v1.9.3:

--- a/swift/pipeline.yaml
+++ b/swift/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
     command: "swift build --cache-path $SWIFT_CACHE_PATH"
     plugins:
       - docker#v5.9.0:
-          image: "swift:latest"
+          image: "swift:5.10"
       - artifacts#v1.9.3:
           upload: "$SWIFT_CACHE_PATH"
           compressed: cache.tgz
@@ -24,7 +24,7 @@ steps:
     depends_on: ["build"]
     plugins:
       - docker#v5.9.0:
-          image: "swift:latest"
+          image: "swift:5.10"
       - artifacts#v1.9.3:
           download: "$SWIFT_CACHE_PATH"
           compressed: cache.tgz


### PR DESCRIPTION
Where appropriate, use the specific docker image version tag over `latest`.

This makes templates slightly more robust and improves the preview. 