### PR TITLE
Fix url in Terraform Docker README

### DIFF
--- a/terraform-docker/README.md
+++ b/terraform-docker/README.md
@@ -26,7 +26,7 @@ This template:
 2. Initializes Terraform and plans changes, outputting a plan file, which is available as an [artifact](https://buildkite.com/docs/pipelines/artifacts).
 3. Blocks for input before conditionally applying the proposed Terraform plan.
 
-The pipeline runs all steps in a Docker container with the [HashiCorp Terraform image]([url](https://hub.docker.com/r/hashicorp/terraform)).
+The pipeline runs all steps in a Docker container with the [HashiCorp Terraform image](https://hub.docker.com/r/hashicorp/terraform).
 
 ## Next steps
 


### PR DESCRIPTION
👋 I was going to ping @dannymidnight and then I thought I'd make an issue for triage but... I'm already here so I hope a PR is ok.

This got pinged by ahrefs as a broken redirect, I think it's just a misformed markdown that ends up as a weird url `https://buildkite.com/pipelines/templates/iac/%5Burl%5D(https://hub.docker.com/r/hashicorp/terraform)`.