### PR TITLE
Add template for deploying to AWS ECS

### DIFF
--- a/aws-ecs-deploy/README.md
+++ b/aws-ecs-deploy/README.md
@@ -1,0 +1,42 @@
+---
+title: CI/CD for AWS ECS
+description: Build and push a Docker image to AWS ECR and trigger an AWS ECS deployment.
+author: Buildkite
+use_cases: ["CD", "CI"]
+platforms: ["AWS"]
+languages: []
+tools: []
+primary_emojis: [":aws-logo:", ":ecs:"]
+---
+
+# CI/CD for AWS ECS
+
+This templates gives you a continuous deployment (CD) pipeline that builds and deploys the latest version of an AWS ECR hosted Docker image to AWS ECS.
+
+At a glance:
+
+- For [Docker](https://www.docker.com/) applications
+- Requires [AWS CLI](https://aws.amazon.com/cli/)
+- Uses the [AWS Assume Role](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin) plugin to access AWS credentials
+- Uses [ECR](https://aws.amazon.com/ecr) for hosting images
+- Deploys to [AWS ECS](https://aws.amazon.com/ecs/)
+
+## How it works
+
+This template:
+
+1. Builds a Docker image
+2. Assumes an AWS role using the AWS Assume Role with Web Identity plugin.
+3. Pushes a tagged Docker image to an AWS ECR registry.
+4. Deploys an AWS ECS service with the latest image.
+5. Waits for the AWS ECS service to stabilize.
+
+## Next steps
+
+After you select **Use template**, you’ll:
+
+1. Connect the Git repository with your project.
+2. Replace the placeholder AWS `ROLE_ARN` in the pipeline definition with a role an IAM role that has permission to manage ECS and ECR.
+3. Replace the placeholder `IMAGE_NAME`, `SERVICE` and `CLUSTER` in the pipeline definition to match your project.
+4. Configure the compute—run locally, on-premises, or in the cloud.
+5. Run the pipeline.

--- a/aws-ecs-deploy/example-project/Dockerfile
+++ b/aws-ecs-deploy/example-project/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/aws-ecs-deploy/example-project/index.html
+++ b/aws-ecs-deploy/example-project/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/aws-ecs-deploy/pipeline.yaml
+++ b/aws-ecs-deploy/pipeline.yaml
@@ -1,0 +1,28 @@
+env:
+  ROLE_ARN: arn:aws:iam::$AWS_ACCOUNT_ID:role/my-role
+  IMAGE_NAME: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/my-repo
+  CLUSTER: my-cluster
+  SERVICE: my-service
+  AWS_PAGER: "" # Disable AWS CLI pagination in CI
+
+steps:
+  - name: ":ecr: Push image"
+    key: "push-image"
+    command: |
+      docker build --platform=linux/amd64 -t $IMAGE_NAME:latest .
+      docker push $IMAGE_NAME:latest
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role_arn: $ROLE_ARN
+      - ecr#v2.8.0:
+          login: true
+
+  - name: ":ecs: Deploy service"
+    depends_on: "push-image"
+    timeout_in_minutes: 5
+    command: |
+      aws ecs update-service --cluster $CLUSTER --service $SERVICE --force-new-deployment
+      aws ecs wait services-stable --cluster $CLUSTER --service $SERVICE
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role_arn: $ROLE_ARN


### PR DESCRIPTION
This PR drops in a new template for deploying an image to ECR and ECS.

An improvement on this would be updating an existing task definition but I figured this template is only ever going to be a starting point so it gives a pretty good indication on how you might achieve that.

Tested using an OIDC role with full access to ECR and ECS.

<img width="649" alt="Screenshot 2024-04-08 at 9 06 39 am" src="https://github.com/buildkite/templates/assets/656826/6967e195-3086-4805-b6b0-cb9a21f9c5a9">
