### PR TITLE
Add template for AWS ECR image scanning

### DIFF
--- a/aws-ecr-scan/README.md
+++ b/aws-ecr-scan/README.md
@@ -15,10 +15,10 @@ This templates gives you a continuous deployment (CI) pipeline that builds and p
 
 At a glance:
 
-- For [Docker](https://www.docker.com/) projects
-- Requires [AWS CLI](https://aws.amazon.com/cli/)
+- For [Docker](https://www.docker.com/) images
+- Requires the [AWS CLI](https://aws.amazon.com/cli/)
 - Uses the [AWS Assume Role](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin) plugin to access AWS credentials
-- Uses [ECR](https://aws.amazon.com/ecr) for image security scanning.
+- Uses the [ECR Scan Results](https://github.com/cultureamp/ecr-scan-results-buildkite-plugin) plugin for configuring [ECR](https://aws.amazon.com/ecr) image scanning
 
 ## How it works
 

--- a/aws-ecr-scan/README.md
+++ b/aws-ecr-scan/README.md
@@ -1,0 +1,40 @@
+---
+title: Scan image using AWS ECR
+description: Build, push, a scan a Docker image for security   vulnerabilities using AWS ECR.
+author: Buildkite
+use_cases: ["Security", "CI"]
+platforms: ["AWS"]
+languages: []
+tools: ["Docker"]
+primary_emojis: [":aws-logo:", ":ecr:"]
+---
+
+# Scan image using AWS ECR
+
+This templates gives you a continuous deployment (CI) pipeline that builds and pushes a Docker image to AWS ECR for image security scanning.
+
+At a glance:
+
+- For [Docker](https://www.docker.com/) projects
+- Requires [AWS CLI](https://aws.amazon.com/cli/)
+- Uses the [AWS Assume Role](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin) plugin to access AWS credentials
+- Uses [ECR](https://aws.amazon.com/ecr) for image security scanning.
+
+## How it works
+
+This template:
+
+1. Builds a Docker image
+2. Assumes an AWS role using the AWS Assume Role with Web Identity plugin.
+3. Pushes a tagged Docker image to an AWS ECR registry.
+4. Audits for security vulerabilities using AWS ECR image scanning.
+
+## Next steps
+
+After you select **Use template**, you’ll:
+
+1. Connect the Git repository with your project.
+2. Using an AWS IAM role with the appropriate ECR policies, replace the placeholder `ROLE_ARN` in the pipeline definition.
+in the pipeline definition to match your project.
+3. Configure the compute—run locally, on-premises, or in the cloud.
+4. Run the pipeline.

--- a/aws-ecr-scan/example-project/Dockerfile
+++ b/aws-ecr-scan/example-project/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/aws-ecr-scan/example-project/index.html
+++ b/aws-ecr-scan/example-project/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello World</h1>
+  </body>
+</html>

--- a/aws-ecr-scan/pipeline.yaml
+++ b/aws-ecr-scan/pipeline.yaml
@@ -1,0 +1,23 @@
+env:
+  ROLE_ARN: arn:aws:iam::$AWS_ACCOUNT_ID:role/my-role
+  IMAGE_NAME: $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/my-repo
+
+steps:
+  - label: ":ecr: Push image"
+    key: "push"
+    command: |
+      docker build --platform=linux/amd64 -t $IMAGE_NAME:$BUILDKITE_BUILD_NUMBER .
+      docker push $IMAGE_NAME:$BUILDKITE_BUILD_NUMBER
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role_arn: $ROLE_ARN
+      - ecr#v2.8.0:
+          login: true
+
+  - label: ":ecr: Scan image"
+    depends_on: "push"
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role-arn: $ROLE_ARN
+      - buildkite/ecr-scan-results#v1.3.0:
+          image-name: $IMAGE_NAME:$BUILDKITE_BUILD_NUMBER

--- a/aws-ecr-scan/pipeline.yaml
+++ b/aws-ecr-scan/pipeline.yaml
@@ -19,5 +19,5 @@ steps:
     plugins:
       - aws-assume-role-with-web-identity#v1.0.0:
           role-arn: $ROLE_ARN
-      - buildkite/ecr-scan-results#v1.3.0:
+      - cultureamp/ecr-scan-results#v1.5.0:
           image-name: $IMAGE_NAME:$BUILDKITE_BUILD_NUMBER

--- a/aws-ecs-deploy/README.md
+++ b/aws-ecs-deploy/README.md
@@ -36,7 +36,7 @@ This template:
 After you select **Use template**, you’ll:
 
 1. Connect the Git repository with your project.
-2. Replace the placeholder AWS `ROLE_ARN` in the pipeline definition with a role an IAM role that has permission to manage ECS and ECR.
+2. Using an AWS IAM role with the appropriate ECR and ECS policies, replace the placeholder `ROLE_ARN` in the pipeline definition.
 3. Replace the placeholder `IMAGE_NAME`, `SERVICE` and `CLUSTER` in the pipeline definition to match your project.
 4. Configure the compute—run locally, on-premises, or in the cloud.
 5. Run the pipeline.


### PR DESCRIPTION
Following on from https://github.com/buildkite/templates/pull/103 this adds a security flavoured AWS ECR template using the  CultureAmp [ecr-scan-results](https://github.com/cultureamp/ecr-scan-results-buildkite-plugin) plugin.

e.g.
<img width="1624" alt="Screenshot 2024-04-08 at 3 14 48 pm" src="https://github.com/buildkite/templates/assets/656826/017ea202-7420-4884-809d-c882df37def3">
