### PR TITLE
Fixes for Fastlane template

### DIFF
--- a/fastlane-ios/README.md
+++ b/fastlane-ios/README.md
@@ -29,7 +29,7 @@ This template:
    - Builds the app with [gym](https://docs.fastlane.tools/actions/gym/).
 3. Adds any test failures as annotations using [junit-annotate-buildkite-plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin).
 
-The lint, test, and build steps all run in parallel. The `beta` step runs on `beta` and `beta/*` branches, after the build step has completed.
+After the depedencies are installed, the lint, test, and build steps all run in parallel. After the build step has completed, the `beta` step runs on `beta` and `beta/*` branches.
 
 Note, depending on your version of Xcode you may need to install `xcbeautify`, which is the [recommended `xcodebuild` formatter](https://docs.fastlane.tools/best-practices/xcodebuild-formatters/).
 

--- a/fastlane-ios/README.md
+++ b/fastlane-ios/README.md
@@ -27,7 +27,7 @@ This template:
    - Runs unit testing with [scan](http://docs.fastlane.tools/actions/run_tests/#whats-scan).
    - Performs static analysis on the codebase with [Swiftlint](https://github.com/realm/SwiftLint).
    - Builds the app with [gym](https://docs.fastlane.tools/actions/gym/).
-3. Adds any test failures as annotations using [junit-annotate-buildkite-plugin](https://buildkite.com/docs/agent/v3/cli-annotate#using-annotations-to-report-test-results).
+3. Adds any test failures as annotations using [junit-annotate-buildkite-plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin).
 
 The lint, test, and build steps all run in parallel. The `beta` step runs on `beta` and `beta/*` branches, after the build step has completed.
 

--- a/fastlane-ios/README.md
+++ b/fastlane-ios/README.md
@@ -27,8 +27,11 @@ This template:
    - Runs unit testing with [scan](http://docs.fastlane.tools/actions/run_tests/#whats-scan).
    - Performs static analysis on the codebase with [Swiftlint](https://github.com/realm/SwiftLint).
    - Builds the app with [gym](https://docs.fastlane.tools/actions/gym/).
+3. Adds any test failures as annotations using [junit-annotate-buildkite-plugin](https://buildkite.com/docs/agent/v3/cli-annotate#using-annotations-to-report-test-results).
 
-After the depedencies are installed, the lint, test, and build steps all run in parallel.
+The lint, test, and build steps all run in parallel. The `beta` step runs on `beta` and `beta/*` branches, after the build step has completed.
+
+Note, depending on your version of Xcode you may need to install `xcbeautify`, which is the [recommended `xcodebuild` formatter](https://docs.fastlane.tools/best-practices/xcodebuild-formatters/).
 
 ## Next steps
 
@@ -42,4 +45,5 @@ After you select **Use template**, you’ll:
    - `test`: Runs unit tests with the [`run_tests`](http://docs.fastlane.tools/actions/run_tests) action.
    - `lint`: Runs Swift code validation using [Swiftlint](http://docs.fastlane.tools/actions/swiftlint).
    - `build`: Builds the app using [gym](http://docs.fastlane.tools/actions/gym).
-4. Run the pipeline.
+   - `beta`: Submits your build to your beta provider.
+6. Run the pipeline.

--- a/fastlane-ios/example-project/fastlane/Fastfile
+++ b/fastlane-ios/example-project/fastlane/Fastfile
@@ -17,6 +17,7 @@ default_platform(:ios)
 
 platform :ios do
   
+  source_folder = "myProject"
   project_path = "myProject/myProject.xcodeproj"
 
   desc "Run iOS tests"
@@ -28,7 +29,10 @@ platform :ios do
 
   desc "Run SwiftLint"
   lane :lint do
-    swiftlint(mode: :lint)
+    swiftlint(
+      mode: :lint,
+      path: source_folder
+    )
   end
 
   desc "Run build"

--- a/fastlane-ios/example-project/fastlane/Fastfile
+++ b/fastlane-ios/example-project/fastlane/Fastfile
@@ -43,4 +43,11 @@ platform :ios do
       clean: true
     )
   end
+
+  desc "Submit beta"
+  lane :beta do
+    # Here's where you would submit the build to your
+    # beta provider (TestFlight, Hockeyapp, etc)
+    puts "Empty lane"
+  end
 end

--- a/fastlane-ios/pipeline.yaml
+++ b/fastlane-ios/pipeline.yaml
@@ -1,40 +1,67 @@
+env:
+  BUNDLE_PATH: vendor/bundle
+
 steps:
+  - label: ":bundler: Install dependencies"
+    key: deps
+    command: "bundle install --path $BUNDLE_PATH"
+    plugins:
+      - artifacts#v1.9.3:
+          upload: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz
+
   - label: ":fastlane: Test"
     key: test
-    commands:
-      - "bundle install --path vendor/bundle"
-      - "bundle exec fastlane ios test"
+    depends_on: deps
+    command: "bundle exec fastlane ios test"
     env:
       LC_ALL: "en_US.UTF-8"
     artifact_paths:
       - "fastlane/test_output/**/*"
+    plugins:
+      - artifacts#v1.9.3:
+          download: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz
 
   - label: ":buildkite: Annotate"
-    depends_on: "test"
+    depends_on:
+      - deps
+      - test
     allow_dependency_failure: true
     plugins:
       - junit-annotate#v2.4.1:
           artifacts: fastlane/test_output/*.junit
 
   - label: ":fastlane: Lint"
-    commands:
-      - "bundle exec fastlane ios lint"
+    depends_on: deps
+    command: "bundle exec fastlane ios lint"
     env:
       LC_ALL: "en_US.UTF-8"
+    plugins:
+      - artifacts#v1.9.3:
+          download: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz
 
   - label: ":fastlane: Build"
     key: build
-    commands:
-      - "bundle install --path vendor/bundle"
-      - "bundle exec fastlane ios build"
+    depends_on: deps
+    command: "bundle exec fastlane ios build"
     env:
       LC_ALL: "en_US.UTF-8"
+    plugins:
+      - artifacts#v1.9.3:
+          download: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz
 
   - label: ":ios: Submit beta"
-    depends_on: build
+    depends_on:
+      - deps
+      - build
     branches: "beta beta/*"
-    commands:
-      - "bundle install --path vendor/bundle"
-      - "bundle exec fastlane ios beta"
+    command: "bundle exec fastlane ios beta"
     env:
       LC_ALL: "en_US.UTF-8"
+    plugins:
+      - artifacts#v1.9.3:
+          download: "$BUNDLE_PATH"
+          compressed: $BUNDLE_PATH.tgz

--- a/fastlane-ios/pipeline.yaml
+++ b/fastlane-ios/pipeline.yaml
@@ -1,24 +1,40 @@
 steps:
-  - label: ":bundler: Install dependencies"
-    command: "bundle install --path vendor/bundle"
-    key: "deps"
-
   - label: ":fastlane: Test"
-    command: "bundle exec fastlane ios test"
-    depends_on: "deps"
-    env:
-      LC_ALL: "en_US.UTF-8"
-
-  - label: ":fastlane: Lint"
-    command: "bundle exec fastlane ios lint"
-    depends_on: "deps"
-    env:
-      LC_ALL: "en_US.UTF-8"
-
-  - label: ":fastlane: Build"
-    command: "bundle exec fastlane ios build"
-    depends_on: "deps"
+    key: test
+    commands:
+      - "bundle install --path vendor/bundle"
+      - "bundle exec fastlane ios test"
     env:
       LC_ALL: "en_US.UTF-8"
     artifact_paths:
       - "fastlane/test_output/**/*"
+
+  - label: ":buildkite: Annotate"
+    depends_on: "test"
+    allow_dependency_failure: true
+    plugins:
+      - junit-annotate#v2.4.1:
+          artifacts: fastlane/test_output/*.junit
+
+  - label: ":fastlane: Lint"
+    commands:
+      - "bundle exec fastlane ios lint"
+    env:
+      LC_ALL: "en_US.UTF-8"
+
+  - label: ":fastlane: Build"
+    key: build
+    commands:
+      - "bundle install --path vendor/bundle"
+      - "bundle exec fastlane ios build"
+    env:
+      LC_ALL: "en_US.UTF-8"
+
+  - label: ":ios: Submit beta"
+    depends_on: build
+    branches: "beta beta/*"
+    commands:
+      - "bundle install --path vendor/bundle"
+      - "bundle exec fastlane ios beta"
+    env:
+      LC_ALL: "en_US.UTF-8"


### PR DESCRIPTION
While playing with Fastlane for an upcoming blog, I ran into these issues with the current template/sample project:

- The `deps` step may run on a different agent to the rest of the steps, meaning dependencies may not be installed.
- `swiftlint` tries to run on the files in the `vendor` folder as well.
- Test output doesn't get saved from the testing step.

I've rewritten the template a bit to perform the `bundle` dep installation at the start of each step, and also to run the test output through our [junit annotation plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin) out of the box. In addition, I was stuck for a while on `xcpretty` (the default xcodebuild formatter) not playing nicely with the newest version of Xcode, so added a note there about installing `xcbeautify`.

Adding the `beta` lane is just something I've seen a fair few other projects that use Fastlane+CI do, so figured it made sense to add it and show off `depends_on` a bit more.

Thank you! Reach out if you want to chat about this, happy to pair! 🥳 