### PR TITLE
Remove assumed build target to make the Bazel template more flexible

### DIFF
--- a/bazel-ci/pipeline.yaml
+++ b/bazel-ci/pipeline.yaml
@@ -1,6 +1,6 @@
 steps:
   - label: ":bazel: Build"
-    command: bazel build //src:bazel
+    command: bazel build //...
 
   - label: ":bazel: Test"
     command: bazel test --build_tests_only //...


### PR DESCRIPTION
The template currently assumes there's a `build` target named `src:bazel`, which generally won't be the case. This change adjusts the target to build everything in the repo with `//...` so it works out of the box (and aligns with the `test` step, which does the same).

Verified with my own project here: https://buildkite.com/nunciato/bazel-buildkite-from-template/builds/2