### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -16,8 +16,12 @@ steps:
       - label: ":buildkite: Validate pipelines"
         command: npm run validatePipeline
         plugins: &node
-          - aws-assume-role-with-web-identity#v1.1.0:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-templates
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
           - aws-ssm#v1.0.0:
               parameters:
                 DATO_API_TOKEN: /pipelines/buildkite/templates/dato-api-token
@@ -67,8 +71,12 @@ steps:
       - label: ":datocms: Publish templates"
         command: npm run publishContent
         plugins:
-          - aws-assume-role-with-web-identity#v1.1.0:
+          - aws-assume-role-with-web-identity#v1.4.0:
               role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-templates
+              session-tags:
+                - organization_slug
+                - organization_id
+                - pipeline_slug
           - aws-ssm#v1.0.0:
               parameters:
                 DATO_API_TOKEN: /pipelines/buildkite/templates/dato-api-token


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dev/pull/476

I haven't updated all the templates as I'm not fully across how the team uses them, but I think we should as session tags are now our [recommended approach in our docs](https://buildkite.com/docs/pipelines/security/oidc/aws)